### PR TITLE
PointerDict for 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "JSONPointer"
 uuid = "cc3ff66e-924d-4e6b-b111-1d9960e4bba9"
 authors = ["김용희 <yongheekim@devsisters.com>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]

--- a/src/JSONPointer.jl
+++ b/src/JSONPointer.jl
@@ -1,9 +1,11 @@
 module JSONPointer
 
+using DataStructures
 import OrderedCollections
 
 include("pointer.jl")
+include("pointer_dict.jl")
 
-export @j_str
+export @j_str, PointerDict
 
 end # module

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -131,32 +131,6 @@ function Base.show(io::IO, ::Pointer{Nothing})
     print(io, "JSONPointer{Nothing}(\"\")")
 end
 
-# This code block needs some explaining.
-#
-# Ideally, one would define methods like Base.haskey(::AbstractDict, ::Pointer).
-# However, this causes an ambiguity with Base.haskey(::Dict, key), which has a
-# more concrete first argument and a less concrete second argument. We could
-# just define both methods to avoid the ambiguity with Dict, but this would
-# probably break any package which defines an <:AbstractDict and fails to type
-# the second argument to haskey, getindex, etc!
-#
-# To avoid the ambiguity issue, we have to manually encode each AbstractDict
-# subtype that we support :(
-for T in (Dict, OrderedCollections.OrderedDict)
-    @eval begin
-        # This method is used when creating new dictionaries from JSON pointers.
-        function $T{K, V}(kv::Pair{<:Pointer, V}...) where {V, K<:Pointer}
-            return $T{String, Any}()
-        end
-
-        _new_container(::$T) = $T{String, Any}()
-
-        Base.haskey(dict::$T, p::Pointer) = _haskey(dict, p)
-        Base.getindex(dict::$T, p::Pointer) = _getindex(dict, p)
-        Base.setindex!(dict::$T, v, p::Pointer) = _setindex!(dict, v, p)
-        Base.get(dict::$T, p::Pointer, default) = _get(dict, p, default)
-    end
-end
 
 Base.getindex(A::AbstractArray, p::Pointer) = _getindex(A, p)
 Base.haskey(A::AbstractArray, p::Pointer) = _haskey(A, p)

--- a/src/pointer_dict.jl
+++ b/src/pointer_dict.jl
@@ -1,0 +1,98 @@
+struct PointerDict
+    d::AbstractDict{K,V} where {K,V}
+
+    PointerDict() = new(Dict{String,Any}())
+    function PointerDict(ps::Pair{Pointer, V}...) where V 
+        d = Dict{String, Any}()
+        for kv in ps
+            _setindex!(d, v, k)
+        end
+        new(d)
+    end    
+end
+PointerDict(kv::AbstractArray{Pair{K,V}}) where {K,V}  = PointerDict(kv...)
+
+# function PointerDict(ps::Pair...)
+#     md = Dict(ps...)
+#     return PointerDict(md)
+# end
+function PointerDict(kv::Pair{Pointer, V}) where V 
+    d = Dict{String, Any}()
+    _setindex!(d, kv[2], kv[1])
+    d
+end
+
+
+## Functions
+
+## Most functions are simply delegated to the wrapped Dict
+DataStructures.@delegate PointerDict.d [Base.get, Base.get!, Base.getkey,
+                        Base.length, Base.isempty, Base.eltype,
+                        Base.iterate, Base.keys, Base.values, sizehint!, 
+                        Base.copy, Base.empty, Base.delete!, Base.empty!,
+                        Base.in, Base.pop!, Base.push!, Base.count, 
+                        Base.size]
+
+# ==============================================================================
+Base.haskey(::PointerDict, ::Pointer{Nothing}) = true
+
+function Base.haskey(collection::PointerDict, p::Pointer)
+    for token in p.tokens
+        if !_haskey(collection, token)
+            return false
+        end
+        collection = _checked_get(collection, token)
+    end
+    return true
+end
+
+_haskey(collection::PointerDict, token::String) = _haskey(collection.d, token)
+_haskey(collection::AbstractDict, token::String) = haskey(collection, token)
+function _haskey(collection::AbstractArray, token::Int)
+    return 1 <= token <= length(collection)
+end
+
+# ==============================================================================
+
+Base.getindex(collection::PointerDict, i) = getindex(collection.d, i)
+Base.getindex(collection::PointerDict, ::Pointer{Nothing}) = collection
+
+function Base.getindex(collection::PointerDict, p::Pointer)
+    return _getindex(collection.d, p.tokens)
+end
+
+function _getindex(collection::AbstractDict, tokens::Vector{Union{String, Int}})
+    for token in tokens
+        collection = _checked_get(collection, token)
+    end
+    return collection
+end
+
+# ==============================================================================
+_checked_get(collection::PointerDict, token::String) = _checked_get(collection.d, token)
+_checked_get(collection::AbstractDict, token::String) = collection[token]
+_checked_get(collection::AbstractArray, token::Int) = collection[token]
+
+function _checked_get(collection, token)
+    error(
+        "JSON pointer does not match the data-structure. I tried (and " *
+        "failed) to index $(collection) with the key: $(token)"
+    )
+end
+
+function Base.setindex!(
+    collection::PointerDict, v, p::Pointer{U}
+) where {U}
+    v = _convert_v(v, p)
+    prev = collection
+    for (i, token) in enumerate(p.tokens)
+        _prep_prev(prev, token)
+        if i < length(p)
+            if ismissing(_checked_get(prev, token))
+                setindex!(prev, _new_data(prev, p.tokens[i + 1]), token)
+            end
+            prev = _checked_get(prev, token)
+        end
+    end
+    return setindex!(prev, v, p.tokens[end])
+end

--- a/src/pointer_dict.jl
+++ b/src/pointer_dict.jl
@@ -57,16 +57,14 @@ end
 
 # ==============================================================================
 Base.getindex(A::AbstractArray, p::Pointer) = _getindex(A, p.tokens)
-function Base.getindex(collection::AbstractDict, p::Pointer) 
-    _getindex(collection, p.tokens)
-end
+
 function Base.getindex(collection::PointerDict, p::Pointer)
     return _getindex(collection.d, p.tokens)
 end
 Base.getindex(collection::PointerDict, i) = getindex(collection.d, i)
 Base.getindex(collection::PointerDict, ::Pointer{Nothing}) = collection
 
-
+_getindex(collection, p::Pointer) = _getindex(collection, p.tokens) 
 function _getindex(collection, tokens::Vector{Union{String, Int}})
     for token in tokens
         collection = _checked_get(collection, token)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using JSONPointer
 using OrderedCollections
 
 @testset "Basic Tests" begin
-    doc = Dict(
+    doc = PointerDict(
         "foo" => ["bar", "baz"],
         "" => 0,
         "a/b" => 1,
@@ -49,7 +49,7 @@ using OrderedCollections
 end
 
 @testset "URI Fragment Tests" begin
-    doc = Dict(
+    doc = PointerDict(
         "foo" => ["bar", "baz"],
         ""=> 0,
         "a/b"=> 1,
@@ -103,30 +103,26 @@ end
 
 @testset "construct Dict with JSONPointer" begin
     p1 = j"/a/1/b"
-    p2 = j"/cd/2/ef"
+    p2 = j"/c/2/d"
 
-    data = Dict(p1 =>1, p2 => 2)
-    @test data[p1] == 1
-    @test data[p2] == 2
+    data = PointerDict(p1 =>1, p2 => 2)
     @test haskey(data, p1)
     @test haskey(data, p2)
+    @test data[p1] == 1
+    @test data[p2] == 2
+    @test data[p1] == data["a"][1]["b"]
+    @test data[p2] == data["c"][2]["d"]
+
     @test !haskey(data, j"/x")
     @test !haskey(data, j"/ba/5")
-
-    p1 = j"/ab/1"
-    p2 = j"/cd/2/ef"
-
-    data = OrderedDict(p1 => "This", p2 => "Is my Data")
-    @test data[p1] == "This"
-    @test data[p2] == "Is my Data"
 end
 
 @testset "access deep nested object" begin
-    data = [Dict("a" => 10)]
+    data = [PointerDict("a" => 10)]
     @test data[j"/1/a"] == 10
 
     p1 = j"/a/b/c/d/e/f/g/1/2/a/b/c"
-    data = Dict(p1 => "sooo deep")
+    data = PointerDict(p1 => "sooo deep")
     @test data[p1] == "sooo deep"
     @test get(data, p1, missing) == "sooo deep"
 
@@ -163,7 +159,7 @@ end
     p2 = j"/\559"
     p3 = j"/\900/10"
 
-    d = Dict(p1 => 1, p2 => 2, p3 => 3)
+    d = PointerDict(p1 => 1, p2 => 2, p3 => 3)
     @test d[p1] == 1
     @test d["5"] == 1
     @test d[p2] == 2
@@ -173,21 +169,21 @@ end
     @test isa(d["900"], Array)
 end
 
-@testset "unique" begin
-    p = [j"/a", j"/b", j"/a"]
-    up = unique(p)
-    @test length(up) == 2
-    @test j"/a" in up
-    @test j"/b" in up
-end
+# @testset "unique" begin
+#     p = [j"/a", j"/b", j"/a"]
+#     up = unique(p)
+#     @test length(up) == 2
+#     @test j"/a" in up
+#     @test j"/b" in up
+# end
 
 @testset "Failed setindex!" begin
-    d = Dict("a" => [1])
+    d = PointerDict("a" => [1])
     @test_throws ErrorException d[j"/a/b"] = 1
 end
 
 @testset "grow object and array" begin
-    d = Dict(j"/a" => Dict())
+    d = PointerDict(j"/a" => Dict())
     d[j"/a/b"] = []
     d[j"/a/b/2"] = 1
     d[j"/a/b/5"] = 2
@@ -206,19 +202,17 @@ end
     p5 = j"/a/5::boolean"
     p6 = j"/a/6::null"
 
-    data = Dict(p1 =>"string", p2 => 1, p3 => Dict(), p4 => [], p5 => true, p6 => missing)
+    data = PointerDict(p1 =>"string", p2 => 1, p3 => Dict(), p4 => [], p5 => true, p6 => missing)
     @test data[p1] == "string"
     @test data[p2] == 1
     
     @test_throws ErrorException data[p1] = 1
     @test_throws ErrorException data[p2] = "string"
     
-    d = Dict(p1 =>missing, p2 => missing, p3 => missing, p4 => missing, p5 => missing)
+    d = PointerDict(p1 =>missing, p2 => missing, p3 => missing, p4 => missing, p5 => missing)
     @test d[p1] == ""
     @test d[p2] == 0
     @test isa(d[p3], OrderedDict)
     @test isa(d[p4], Array{Any, 1})
     @test d[p5] == false
-
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,6 +154,33 @@ end
     @test_broken get(data, j"/1", missing) |> ismissing
 end
 
+@testset "Pointer with AbstractDict" begin 
+    doc = Dict(
+        "foo" => ["bar", "baz"],
+        "a"   => 1, 
+        "b"   => OrderedDict("c" => 2) 
+    )
+
+    @test JSONPointer._getindex(doc, j"/foo") ==  ["bar", "baz"] 
+    @test JSONPointer._getindex(doc, j"/foo/1") ==  "bar"
+    @test JSONPointer._getindex(doc, j"/b/c") ==  2
+    @test JSONPointer._getindex(doc, j"/a") ==  1 
+
+    @test JSONPointer._haskey(doc, j"/foo")
+    @test JSONPointer._haskey(doc, j"/foo/2")
+    @test JSONPointer._haskey(doc, j"/b/c")
+    @test JSONPointer._haskey(doc, j"/a")
+    
+    
+    @test !JSONPointer._haskey(doc, j"/d")
+    @test !JSONPointer._haskey(doc, j"/foo/3")
+    
+    JSONPointer._setindex!(doc, 3, j"/d")
+    @test JSONPointer._getindex(doc, j"/d") ==  3 
+    JSONPointer._setindex!(doc, "faz", j"/foo/3")
+    @test JSONPointer._getindex(doc, j"/foo/3") ==  "faz"
+end
+
 @testset "literal string for a Number" begin
     p1 = j"/\5"
     p2 = j"/\559"
@@ -168,14 +195,6 @@ end
     @test d[p3] == 3
     @test isa(d["900"], Array)
 end
-
-# @testset "unique" begin
-#     p = [j"/a", j"/b", j"/a"]
-#     up = unique(p)
-#     @test length(up) == 2
-#     @test j"/a" in up
-#     @test j"/b" in up
-# end
 
 @testset "Failed setindex!" begin
     d = PointerDict("a" => [1])


### PR DESCRIPTION
This is my draft for https://github.com/devsisters/JSONPointer.jl/issues/11 
@odow would you mind review this PR when you have time?

here is my change list

1.  remove seamless support for `Dict` and `OrderedDict`, users need to call different name for `getindex`, `setindex`, `haskey` method 
https://github.com/devsisters/JSONPointer.jl/blob/755772255b0251fd28f6d82b0fcb69839705a01f/test/runtests.jl#L157-L180
>TODO: better method name 

2. If the user wants seamless handling with `JSONPointer`, then wrapped dictionary `PointerDict` can be used 
``` julia    
data= PointerDict()
data[j"/a/b"] = 1 
data["j/a/b"] == 1 
haskey(data, j"/a/b") == true
get(data, j"/c", missing) == missing 
```
>TODO: interface to decide which `AbstractDict` to use. something like `PointerDict{Dict}()`, `PointerDict{OrderedDict}()` ?

https://github.com/devsisters/JSONPointer.jl/blob/755772255b0251fd28f6d82b0fcb69839705a01f/src/pointer_dict.jl#L4

